### PR TITLE
Don't fix sidebar

### DIFF
--- a/gui/src/App.vue
+++ b/gui/src/App.vue
@@ -60,7 +60,6 @@
 
 <style>
     .sidebar {
-        position: fixed;
         top: 0;
         bottom: 0;
         left: 0;


### PR DESCRIPTION
CSS `fixed` property will remove the element from the document flow.
It means its container and the other elements will even not be aware of the fixed element.
So the `col` will not affect the sidebar and `main` div will be rendered from the left margin.

I guess the problem is because of the order of CSS.
The production build results in different CSS order from the development mode so we didn't encounter this issue.

Can check this discussion.
https://forum.vuejs.org/t/vuejs-some-css-is-missing-when-creating-a-production-build/54034/2

Although this PR makes the layout looks correct, I don't know if this PR's patch is a good solution.
Perhaps we have to be careful when we try to modify the bootstrap's CSS properties like what we did between <style> tags in App.vue.

For your reference.